### PR TITLE
Add link to component page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ site-search
 `site-search` is a single-line search text field that kicks out to a [site:]
 Google search for a specific domain (by default, the current domain).
 It is a convenience element composed of a `paper-input` and a `paper-icon-button`.
+
+See the [component page](http://polymerlabs.github.io/site-search) for more information.


### PR DESCRIPTION
Just noticed that this was missing :) 

You're probably familiar with the GitHub publish flow for elements, but if not, my [publishing guide](https://www.polymer-project.org/docs/start/reusableelements.html#publishing-a-demo-and-landing-page-for-your-element) talks through using our scripts to push a nicely packaged version of your element to `gh-pages`.

I've done a quick push for this element that should be live here http://polymerlabs.github.io/site-search, but any further pushes will overwrite it so it stays fresh. 
